### PR TITLE
Basic structure of adding quest almost finished

### DIFF
--- a/Scribe.xcodeproj/project.pbxproj
+++ b/Scribe.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		E71673381D8772F300BA9C6A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E71673361D8772F300BA9C6A /* LaunchScreen.storyboard */; };
 		E71673431D8772F400BA9C6A /* ScribeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71673421D8772F400BA9C6A /* ScribeTests.swift */; };
 		E716734E1D8772F400BA9C6A /* ScribeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E716734D1D8772F400BA9C6A /* ScribeUITests.swift */; };
+		E7993C8A1D8A3FE8007FD980 /* DateExtenstions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7993C891D8A3FE8007FD980 /* DateExtenstions.swift */; };
 		E7DDE8F81D88E94300BE76B3 /* QuestLogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7DDE8F71D88E94300BE76B3 /* QuestLogViewController.swift */; };
 		E7DDE8FA1D88EE6500BE76B3 /* Quest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7DDE8F91D88EE6500BE76B3 /* Quest.swift */; };
 		E7DDE8FC1D88F0EB00BE76B3 /* AddQuestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7DDE8FB1D88F0EB00BE76B3 /* AddQuestViewController.swift */; };
@@ -52,6 +53,7 @@
 		E71673491D8772F400BA9C6A /* ScribeUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ScribeUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E716734D1D8772F400BA9C6A /* ScribeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScribeUITests.swift; sourceTree = "<group>"; };
 		E716734F1D8772F400BA9C6A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E7993C891D8A3FE8007FD980 /* DateExtenstions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateExtenstions.swift; sourceTree = "<group>"; };
 		E7DDE8F71D88E94300BE76B3 /* QuestLogViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuestLogViewController.swift; sourceTree = "<group>"; };
 		E7DDE8F91D88EE6500BE76B3 /* Quest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Quest.swift; sourceTree = "<group>"; };
 		E7DDE8FB1D88F0EB00BE76B3 /* AddQuestViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddQuestViewController.swift; sourceTree = "<group>"; };
@@ -110,6 +112,7 @@
 				E716732E1D8772F300BA9C6A /* Main.storyboard */,
 				E7DDE8FB1D88F0EB00BE76B3 /* AddQuestViewController.swift */,
 				E7DDE8F91D88EE6500BE76B3 /* Quest.swift */,
+				E7993C891D8A3FE8007FD980 /* DateExtenstions.swift */,
 				E7DDE8F71D88E94300BE76B3 /* QuestLogViewController.swift */,
 				E71673341D8772F300BA9C6A /* Assets.xcassets */,
 				E71673361D8772F300BA9C6A /* LaunchScreen.storyboard */,
@@ -273,6 +276,7 @@
 			files = (
 				E7DDE8F81D88E94300BE76B3 /* QuestLogViewController.swift in Sources */,
 				E716732D1D8772F300BA9C6A /* ViewController.swift in Sources */,
+				E7993C8A1D8A3FE8007FD980 /* DateExtenstions.swift in Sources */,
 				E716732B1D8772F300BA9C6A /* AppDelegate.swift in Sources */,
 				E71673331D8772F300BA9C6A /* Scribe.xcdatamodeld in Sources */,
 				E7DDE8FA1D88EE6500BE76B3 /* Quest.swift in Sources */,

--- a/Scribe/Base.lproj/Main.storyboard
+++ b/Scribe/Base.lproj/Main.storyboard
@@ -120,7 +120,7 @@
                                             <constraint firstAttribute="height" constant="50" id="nDO-EP-y9N"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences" returnKeyType="done"/>
                                     </textField>
                                     <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="43X-D5-dHk">
                                         <rect key="frame" x="0.0" y="160" width="600" height="216"/>
@@ -134,7 +134,7 @@
                                             <constraint firstAttribute="height" constant="50" id="d6U-uk-hvV"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences" returnKeyType="next"/>
                                     </textField>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Complete By" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="miU-Yy-pCj">
                                         <rect key="frame" x="0.0" y="128" width="600" height="21"/>
@@ -151,6 +151,7 @@
                                         <constraints>
                                             <constraint firstAttribute="height" constant="155" id="hXA-dz-Exj"/>
                                         </constraints>
+                                        <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                     </textView>
@@ -206,6 +207,8 @@
                         <outlet property="addGivenByField" destination="3BA-Ub-n1S" id="bxq-kA-gF4"/>
                         <outlet property="addNotesView" destination="Q9t-EP-IPj" id="dah-XG-aa6"/>
                         <outlet property="addQuestTitleField" destination="dJE-DT-RyV" id="2YW-OH-SC5"/>
+                        <outlet property="completeByLabel" destination="miU-Yy-pCj" id="yNd-AD-rYh"/>
+                        <outlet property="completionDatePicker" destination="43X-D5-dHk" id="DNs-rR-Z87"/>
                         <outlet property="scrollView" destination="pch-55-atU" id="RCb-9D-756"/>
                         <segue destination="VfZ-uo-ogR" kind="unwind" identifier="saveQuestBtn" unwindAction="saveQuestToQuestLogViewController:" id="Jky-aG-ZHp"/>
                     </connections>

--- a/Scribe/DateExtenstions.swift
+++ b/Scribe/DateExtenstions.swift
@@ -1,0 +1,36 @@
+//
+//  DateExtenstions.swift
+//  Scribe
+//
+//  Created by Anthony Zaprzalka on 9/14/16.
+//  Copyright © 2016 Anthony Zaprzalka. All rights reserved.
+//
+
+import Foundation
+
+extension NSDate {
+
+    // Returns the time as short style hh:mm am/pm
+    func toShortStyleTime() -> String {
+        let formatter = NSDateFormatter()
+        formatter.timeStyle = .ShortStyle
+        
+        return formatter.stringFromDate(self)
+    }
+    
+    // Returns the date as Month + Day
+    func toMonthAndDay() -> String {
+        let formatter = NSDateFormatter()
+        formatter.dateFormat = "MMMM d"
+        
+        return formatter.stringFromDate(self)
+    }
+    
+    // Returns the date in long style Full month, day, year
+    func toLongStyleDate() -> String {
+        let formatter = NSDateFormatter()
+        formatter.dateStyle = .LongStyle
+        
+        return formatter.stringFromDate(self)
+    }
+}

--- a/Scribe/Quest.swift
+++ b/Scribe/Quest.swift
@@ -26,7 +26,6 @@ class Quest {
     var debugTestQuest = questStruct(title: "Test Title", givenBy: "Test Me", notes: "Some test notes", date: NSDate())
     
     
-    
     // Saves the newly created quest to CoreData
     func saveQuest() -> Bool {
         // Saves the quest to CoreData
@@ -42,13 +41,5 @@ class Quest {
         
         // Temp change later
         return false
-    }
-    
-    // Takes NSDate type and converts to string so controller can display to view as text
-    func dateToString(date: NSDate) -> String {
-        let dateFormatter  = NSDateFormatter()
-        dateFormatter.dateStyle = NSDateFormatterStyle.LongStyle
-        
-        return dateFormatter.stringFromDate(date)
     }
 }

--- a/Scribe/ViewController.swift
+++ b/Scribe/ViewController.swift
@@ -65,7 +65,7 @@ class ViewController: UIViewController {
     // Landing page to display upcoming reminder or user pinned reminder
     func displayPinnedQuest(qst: Quest) {
         titleLabel.text = qst.debugTestQuest.title
-        timeRemainingLabel.text = qst.dateToString(qst.debugTestQuest.date)
+        timeRemainingLabel.text = "\(qst.debugTestQuest.date.toMonthAndDay()), \(qst.debugTestQuest.date.toShortStyleTime())"
         givenByLabel.text = qst.debugTestQuest.givenBy
     }
 


### PR DESCRIPTION
Added delegates for all the textFields, Views, and datePicker to allow updates. Page scrolls with each element to be at the top when editing. Custom dismissal keyboard for textView. Changed how dates are received in strings. Instead of coming from the Quest class, an extension of NSDate() was made to support some basic conversions for easier use.
